### PR TITLE
Name Flash in Nav

### DIFF
--- a/src/components/Nav/Nav.astro
+++ b/src/components/Nav/Nav.astro
@@ -17,4 +17,4 @@ const quoteMeta = quotes.map(function ({ data }) {
 });
 ---
 
-<NavBar id={id} quoteMeta={quoteMeta} client:load />
+<NavBar id={id} quoteMeta={quoteMeta} client:only />


### PR DESCRIPTION
The goal of this pull request is to attempt to prevent the nav to flash "Nootropic Cat Treats" when on a different/specific quotee.